### PR TITLE
Fixed tab loading in newer Firefox versions.

### DIFF
--- a/fast-recon.py
+++ b/fast-recon.py
@@ -11,6 +11,10 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 from selenium.common.exceptions import NoSuchFrameException
 from selenium.webdriver.common.keys import Keys
 
+import os
+
+os.environ['MOZ_FORCE_DISABLE_E10S'] = '1'
+
 # If this script no longer fetches any results check the XPath
 
 def parse_args():
@@ -54,13 +58,18 @@ def open_page(br, domain):
     urls.append(g_search_base+'site:pastebin.com+'+domain)
     # Add quotes around domain for pastebin search
     urls.append(g_search_base+'site:pastebin.com+"'+domain+'"')
-    
+
+    tabHandle = 0
     for u in urls:
+        br.switch_to_window(br.window_handles[tabHandle])
         br.get(u)
         # Just grab an element that exists in all pages
         html_elem = br.find_element_by_tag_name('html')
         if u != urls[-1]:
-            html_elem.send_keys(Keys.CONTROL + 't') 
+            html_elem.send_keys(Keys.CONTROL + 't')
+        tabHandle+=1
+	# time.sleep(10) # Optional
+    br.switch_to_window(br.window_handles[0])
 
 def main():
     args = parse_args()


### PR DESCRIPTION
Experienced issues after Firefox updates. New tabs were not being created, causing all URL requests to be opened in only the first tab. We identify a window handle and switch focus to it as we iterate the URLs.